### PR TITLE
罫線を一切表示しないようにした

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,6 @@
     }
     .body{
       font-family:var(--mono);
-      border-top:1px dashed var(--line);
-      border-bottom:1px dashed var(--line);
       padding:10px 0;
       white-space:pre-wrap;
     }


### PR DESCRIPTION
close #5 

## 変更理由

プレビュー時、PDF作成時ともに実際の内容証明の見た目にした方が分かりやすいため